### PR TITLE
feat!: add attribute command

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -117,16 +117,13 @@ impl Action {
                 }
                 Action::View
             }
-            "attribute" => {
-                if args.len() == 0 {
-                    return Err("no attribute specified")?;
-                } else if args.len() > 1 {
-                    return Err("too many arguments")?;
-                }
-                Action::Attribute {
+            "attribute" => match args.len() {
+                0 => Err("no attribute specified")?,
+                1 => Action::Attribute {
                     attribute: Attribute::from_text(&args[0])?,
-                }
-            }
+                },
+                _ => Err("too many arguments")?,
+            },
             "tag" | "untag" => {
                 if args.len() == 0 {
                     return Err("no label specified")?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,8 +52,6 @@ impl Config {
 #[derive(PartialEq, Debug)]
 pub enum Action {
     Start { date: DateTime },
-    Stop { date: DateTime },
-    Skip,
     Mark { date: DateTime },
     Remark { date: DateTime },
     Unmark,
@@ -78,21 +76,6 @@ impl Action {
                 },
                 _ => return Err("too many arguments")?,
             },
-            "stop" => match args.len() {
-                0 => Action::Stop {
-                    date: DateTime::now(),
-                },
-                1 => Action::Stop {
-                    date: DateTime::now().modify(&args[0])?,
-                },
-                _ => return Err("too many arguments")?,
-            },
-            "skip" => {
-                if args.len() != 0 {
-                    return Err("too many arguments")?;
-                }
-                Action::Skip
-            }
             "mark" => match args.len() {
                 0 => Action::Mark {
                     date: DateTime::now(),
@@ -203,24 +186,6 @@ mod tests {
         );
         assert!(Action::build("start", &[String::from("0m"), String::from("hello")]).is_err());
         assert!(Action::build("start", &[String::from("hello")]).is_err());
-
-        assert_eq!(
-            Action::build("stop", &[])?,
-            Action::Stop {
-                date: DateTime::now()
-            }
-        );
-        assert_eq!(
-            Action::build("stop", &[String::from("0m")])?,
-            Action::Stop {
-                date: DateTime::now()
-            }
-        );
-        assert!(Action::build("stop", &[String::from("0m"), String::from("hello")]).is_err());
-        assert!(Action::build("stop", &[String::from("hello")]).is_err());
-
-        assert_eq!(Action::build("skip", &[])?, Action::Skip);
-        assert!(Action::build("skip", &[String::from("hello")]).is_err());
 
         assert_eq!(
             Action::build("mark", &[])?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,9 +113,9 @@ fn attribute(config: &Config, attribute: Attribute) -> Result<(), Box<dyn Error>
         return Err("no active session found")?;
     };
 
-    session.set_attribute(attribute);
+    session.set_attribute(attribute.to_owned());
     session.save()?;
-    // println!("Set attribute: {attribute:?}");
+    println!("Set attribute: {attribute:?}");
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use config::{Action, Config};
 use date_time::DateTime;
-use session::{Aggregator, Session, SessionFile, Tag};
+use session::{Aggregator, Attribute, Session, SessionFile, Tag};
 use std::{env, error::Error, fs, io, path::PathBuf, process::Command};
 
 mod config;
@@ -20,6 +20,7 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn Error>> {
         Action::Unmark => unmark(&config),
         Action::Path => path(&config),
         Action::View => view(&config),
+        Action::Attribute { attribute: attr } => attribute(&config, attr),
         Action::Tag { tag: tag_ } => tag(&config, &tag_),
         Action::Untag { tag } => untag(&config, &tag),
         Action::Write { text } => write(&config, &text),
@@ -104,6 +105,17 @@ fn path(config: &Config) -> Result<(), Box<dyn Error>> {
 fn view(config: &Config) -> Result<(), Box<dyn Error>> {
     let aggregator = Aggregator::build(&config)?;
     println!("{}", aggregator.view());
+    Ok(())
+}
+
+fn attribute(config: &Config, attribute: Attribute) -> Result<(), Box<dyn Error>> {
+    let Some(mut session) = Session::get_last(&config)? else {
+        return Err("no active session found")?;
+    };
+
+    session.set_attribute(attribute);
+    session.save()?;
+    // println!("Set attribute: {attribute:?}");
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,6 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn Error>> {
 
     let out = match action {
         Action::Start { date } => start(&config, &date),
-        Action::Stop { date } => stop(&config, &date),
-        Action::Skip => skip(&config),
         Action::Mark { date } => mark(&config, &date),
         Action::Remark { date } => remark(&config, &date),
         Action::Unmark => unmark(&config),
@@ -56,37 +54,6 @@ fn start(config: &Config, date: &DateTime) -> Result<(), Box<dyn Error>> {
     };
     fs::write(&path, &contents).map_err(|_| "session directory doesn't exist")?;
     println!("Started: {}", &date.to_formatted_time());
-    Ok(())
-}
-
-fn stop(config: &Config, date: &DateTime) -> Result<(), Box<dyn Error>> {
-    let Some(mut session) = Session::get_last(&config)? else {
-        return Err("no active session found")?;
-    };
-
-    session.stop(&date)?;
-    session.save()?;
-    println!(
-        "Stopped: {}\n{}",
-        &date.to_formatted_time(),
-        &Aggregator::build(&config)?
-            .view()
-            .lines()
-            .skip(1)
-            .fold(String::new(), |acc, val| acc + val + "\n")
-            .trim_end_matches("\n")
-    );
-    Ok(())
-}
-
-fn skip(config: &Config) -> Result<(), Box<dyn Error>> {
-    let Some(mut session) = Session::get_last(&config)? else {
-        return Err("no active session found")?;
-    };
-
-    session.skip();
-    session.save()?;
-    println!("Skipped current mark");
     Ok(())
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -213,24 +213,6 @@ impl Session {
         acc
     }
 
-    pub fn stop(&mut self, dt: &DateTime) -> Result<(), &'static str> {
-        if !self.is_active() {
-            return Err("session already ended");
-        }
-        let mut mark = Mark::new(&dt.date);
-        mark.attribute = Attribute::Stop;
-        self.marks.push(mark);
-        Ok(())
-    }
-
-    pub fn skip(&mut self) {
-        let mark = self
-            .marks
-            .last_mut()
-            .expect("session must always have at least one mark");
-        mark.attribute = Attribute::Skip;
-    }
-
     pub fn mark(&mut self, dt: &DateTime) -> Result<(), &'static str> {
         if !self.is_active() {
             return Err("can't mark, session has already ended");
@@ -718,56 +700,6 @@ mod tests {
             marks: vec![mark_first, mark_second],
         };
         assert_eq!(session.get_time(), (1 * 60 * 60 + 26 * 60 + 40) * 1000);
-    }
-
-    #[test]
-    fn session_stop_works() {
-        let config = Config {
-            sessions_path: PathBuf::from("sessions"),
-        };
-        let mut session = Session::new(&config, &DateTime::now());
-        let mut clone = session.clone();
-        session.stop(&DateTime::now()).unwrap();
-        let dt = DateTime::now();
-        let mut mark = Mark::new(&dt.date);
-        mark.attribute = Attribute::Stop;
-        clone.marks.push(mark);
-        assert_eq!(session, clone);
-    }
-
-    #[test]
-    fn cannot_stop_when_session_ended() {
-        let config = Config {
-            sessions_path: PathBuf::from("sessions"),
-        };
-        let mut session = Session::new(&config, &DateTime::now());
-        session.stop(&DateTime::now()).unwrap();
-        let clone = session.clone();
-        assert!(session.stop(&DateTime::now()).is_err());
-        assert_eq!(session, clone);
-    }
-
-    #[test]
-    fn session_skip_works() {
-        let config = Config {
-            sessions_path: PathBuf::from("sessions"),
-        };
-        let mut session = Session::new(&config, &DateTime::now());
-        assert_eq!(session.marks.last_mut().unwrap().attribute, Attribute::None);
-        session.skip();
-        assert_eq!(session.marks.last_mut().unwrap().attribute, Attribute::Skip);
-    }
-
-    #[test]
-    fn session_skip_overwrites_stop() {
-        let config = Config {
-            sessions_path: PathBuf::from("sessions"),
-        };
-        let mut session = Session::new(&config, &DateTime::now());
-        session.stop(&DateTime::now()).unwrap();
-        assert_eq!(session.marks.last_mut().unwrap().attribute, Attribute::Stop);
-        session.skip();
-        assert_eq!(session.marks.last_mut().unwrap().attribute, Attribute::Skip);
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -13,7 +13,7 @@ const MARKS_HEADING: &str = "## Marks";
 const MARK_HEADING_PREFIX: &str = "### ";
 const LABEL_PREFIX: &str = "- ";
 // TODO: Change to "- stop"? Will require renaming all labels to that.
-const LABEL_END: &str = "- end";
+const LABEL_STOP: &str = "- end";
 const LABEL_SKIP: &str = "- skip";
 const LABEL_TAG: &str = "- tag";
 const LABEL_TAG_SURROUND: &str = "`";
@@ -451,7 +451,7 @@ pub enum Attribute {
 impl Attribute {
     fn from_line(text: &str) -> Attribute {
         match text.trim() {
-            LABEL_END => Attribute::Stop,
+            LABEL_STOP => Attribute::Stop,
             LABEL_SKIP => Attribute::Skip,
             _ => Attribute::None,
         }
@@ -459,7 +459,7 @@ impl Attribute {
 
     fn to_line(&self) -> String {
         match self {
-            Attribute::Stop => LABEL_END.to_owned(),
+            Attribute::Stop => LABEL_STOP.to_owned(),
             Attribute::Skip => LABEL_SKIP.to_owned(),
             Attribute::None => String::new(),
         }
@@ -932,7 +932,7 @@ mod tests {
                 \n\
                 {MARK_HEADING_PREFIX}{}\n\
                 \n\
-                {LABEL_END}\n\
+                {LABEL_STOP}\n\
                 ",
             mark_first_dt.to_formatted_pretty(),
             mark_second_dt.to_formatted_pretty(),
@@ -1083,7 +1083,7 @@ mod tests {
             "\
                 {MARK_HEADING_PREFIX}{}\n\
                 \n\
-                {LABEL_END}\n\
+                {LABEL_STOP}\n\
                 {LABEL_TAG} {LABEL_TAG_SURROUND}rust{LABEL_TAG_SURROUND}\n\
                 {LABEL_TAG} {LABEL_TAG_SURROUND}time tracker{LABEL_TAG_SURROUND}\n\
                 \n\
@@ -1108,7 +1108,7 @@ mod tests {
             "\
                 {MARK_HEADING_PREFIX}{}\n\
                 \n\
-                {LABEL_END}\n\
+                {LABEL_STOP}\n\
                 {LABEL_SKIP}\n\
                 \n\
                 This is some content.\n\
@@ -1131,7 +1131,7 @@ mod tests {
             "\
                 {MARK_HEADING_PREFIX}{}\n\
                 \n\
-                {LABEL_END}\n\
+                {LABEL_STOP}\n\
                 {LABEL_TAG} {LABEL_TAG_SURROUND}rust{LABEL_TAG_SURROUND}\n\
                 {LABEL_TAG} {LABEL_TAG_SURROUND}time tracker{LABEL_TAG_SURROUND}\n\
                 \n\
@@ -1185,7 +1185,7 @@ mod tests {
 
     #[test]
     fn attribute_from_line_works() {
-        assert_eq!(Attribute::from_line(LABEL_END), Attribute::Stop);
+        assert_eq!(Attribute::from_line(LABEL_STOP), Attribute::Stop);
         assert_eq!(Attribute::from_line(LABEL_SKIP), Attribute::Skip);
         assert_eq!(Attribute::from_line(LABEL_TAG), Attribute::None);
         assert_eq!(Attribute::from_line("- something else"), Attribute::None);
@@ -1194,7 +1194,7 @@ mod tests {
 
     #[test]
     fn attribute_to_line_works() {
-        assert_eq!(Attribute::Stop.to_line(), LABEL_END);
+        assert_eq!(Attribute::Stop.to_line(), LABEL_STOP);
         assert_eq!(Attribute::Skip.to_line(), LABEL_SKIP);
         assert_eq!(Attribute::None.to_line(), "");
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -580,7 +580,8 @@ mod tests {
         assert_eq!(lines[5], mark_end.to_line());
 
         session_third.marks.pop();
-        session_third.stop(&DateTime::now()).unwrap();
+        session_third.mark(&DateTime::now()).unwrap();
+        session_third.set_attribute(Attribute::Stop);
         let mark = &mut session_third.marks[1];
         mark.date = mark_end.date;
         let mark_end = session_third.marks.last().unwrap();
@@ -675,7 +676,8 @@ mod tests {
         };
         let mut session = Session::new(&config, &DateTime::now());
         assert_eq!(session.end(), session.marks.last().unwrap().date);
-        session.stop(&DateTime::now()).unwrap();
+        session.mark(&DateTime::now()).unwrap();
+        session.set_attribute(Attribute::Stop);
         session.marks.last_mut().unwrap().date = testing::now_plus_secs(30);
         assert_eq!(session.end(), session.marks.last().unwrap().date);
     }
@@ -688,7 +690,8 @@ mod tests {
         let mut session = Session::new(&config, &DateTime::now());
         assert!(session.is_active());
         assert!(session.marks.last().unwrap().attribute != Attribute::Stop);
-        session.stop(&DateTime::now()).unwrap();
+        session.mark(&DateTime::now()).unwrap();
+        session.set_attribute(Attribute::Stop);
         assert!(!session.is_active());
         assert!(session.marks.last().unwrap().attribute == Attribute::Stop);
     }
@@ -754,7 +757,8 @@ mod tests {
             sessions_path: PathBuf::from("sessions"),
         };
         let mut session = Session::new(&config, &DateTime::now());
-        session.stop(&DateTime::now()).unwrap();
+        session.mark(&DateTime::now()).unwrap();
+        session.set_attribute(Attribute::Stop);
         let clone = session.clone();
         assert!(session.mark(&DateTime::now()).is_err());
         assert_eq!(session, clone);

--- a/src/session.rs
+++ b/src/session.rs
@@ -696,7 +696,7 @@ mod tests {
 
     // It ignores `mark_first` and counts to current time, so `mark_second` is the final time.
     #[test]
-    fn session_get_time_ignores_marks_if_they_have_label_skip() {
+    fn session_get_time_ignores_marks_if_they_are_skipped() {
         let mut mark_first = Mark::new(&testing::now_plus_secs(-3 * 60 * 60));
         mark_first.attribute = Attribute::Skip;
         let mark_second = Mark::new(&testing::now_plus_secs(-54 * 60 - 10)); // 54m 10s
@@ -709,7 +709,7 @@ mod tests {
     }
 
     #[test]
-    fn session_get_time_ignores_current_time_if_last_mark_has_label_skip() {
+    fn session_get_time_ignores_current_time_if_last_mark_is_skipped() {
         let mark_first = Mark::new(&testing::now_plus_secs(-3 * 60 * 60));
         let mut mark_second = Mark::new(&testing::now_plus_secs(-1 * 60 * 60 - 33 * 60 - 20)); // 1h 33m 20s
         mark_second.attribute = Attribute::Skip;

--- a/src/session.rs
+++ b/src/session.rs
@@ -12,8 +12,7 @@ const SESSION_TITLE: &str = "Session";
 const MARKS_HEADING: &str = "## Marks";
 const MARK_HEADING_PREFIX: &str = "### ";
 const LABEL_PREFIX: &str = "- ";
-// TODO: Change to "- stop"? Will require renaming all labels to that.
-const LABEL_STOP: &str = "- end";
+const LABEL_STOP: &str = "- stop";
 const LABEL_SKIP: &str = "- skip";
 const LABEL_TAG: &str = "- tag";
 const LABEL_TAG_SURROUND: &str = "`";


### PR DESCRIPTION
Added `attribute` command and removed `stop` and `skip` commands.

Changed `LABEL_STOP`'s value to `- stop`. All session from now on must have `- stop` in the last mark for them to be counted as stopped.
